### PR TITLE
Tempo robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,18 @@
 MEI Lilypond Engraving Refinement
 
 ### MEI2LY
-**mei2ly.xsl** supports already many music elements from MEI and works for checking encoding errors.
+**mei2ly.xsl** transforms MEI to LilyPond and supports already many music elements from MEI and works for checking encoding errors.
 Basic layout features are implemented for global staff size and page layout.
 
-Check the list of [supported](supported.md) elements and attributes. 
+Check the list of [supported elements and attributes](supported.md). 
 
-For now it uses XSLT 2.0. Goal for a later branch is to have an pure XSLT 1.0 version to put on a website, where you can generate a lilypond engraved rendering of a MEI edition on the fly.
+For now it uses XSLT 2.0. Goal for a later branch is to have an pure XSLT 1.0 version to put on a website, where you can generate a lilypond engraved rendering of a MEI edition on the fly. 
+
+And of course you'll need [LilyPond](http://lilypond.org) for engraving your output. 
 
 ### SILLY.xsl
 Along comes **silly.xsl** which *Strips Individual Layout for LilyPond*. It basically removes layout instructions from your MEI (e.g. stem directions) so LilyPond can do it's job. Using this will give you a fine clean LilyPond code with **mei2ly.xsl**.
+
+
+## Example ouput
+![Example page](/examples/Chopin_Etude_op.10_no.9-page1.png)

--- a/mei2ly.xsl
+++ b/mei2ly.xsl
@@ -1644,27 +1644,30 @@
   </xsl:template>
   <!-- MEI tempo -->
   <xsl:template match="mei:tempo" mode="pre">
-    <xsl:if test="@place = 'below'">
-      <xsl:value-of select="'\once \override Score.MetronomeMark.direction = #DOWN '"/>
+    <xsl:variable name="tempoString" select="string(.)"/>
+    <xsl:if test="$tempoString or (@mm.unit and @mm)">
+      <xsl:if test="@place = 'below'">
+        <xsl:value-of select="'\once \override Score.MetronomeMark.direction = #DOWN '"/>
+      </xsl:if>
+      <xsl:if test="@ho or @vo">
+        <xsl:text>\once \override Score.MetronomeMark.extra-offset = #&apos;</xsl:text>
+        <xsl:call-template name="setOffset"/>
+      </xsl:if>
+      <xsl:value-of select="'\tempo '"/>
+      <xsl:if test="$tempoString">
+        <xsl:value-of select="'\markup {'"/>
+        <xsl:apply-templates/>
+        <xsl:value-of select="'} '"/>
+      </xsl:if>
+      <xsl:if test="@mm.unit and @mm">
+        <xsl:value-of select="@mm.unit"/>
+        <xsl:call-template name="setDots">
+          <xsl:with-param name="dots" select="@mm.dots"/>
+        </xsl:call-template>
+        <xsl:value-of select="concat(' = ',@mm)"/>
+      </xsl:if>
+      <xsl:value-of select="'&#10;  '"/>
     </xsl:if>
-    <xsl:if test="@ho or @vo">
-      <xsl:text>\once \override Score.MetronomeMark.extra-offset = #&apos;</xsl:text>
-      <xsl:call-template name="setOffset"/>
-    </xsl:if>
-    <xsl:value-of select="'\tempo '"/>
-    <xsl:if test="string(.)">
-      <xsl:value-of select="'\markup {'"/>
-      <xsl:apply-templates/>
-      <xsl:value-of select="'} '"/>
-    </xsl:if>
-    <xsl:if test="@mm.unit and @mm">
-      <xsl:value-of select="@mm.unit"/>
-      <xsl:call-template name="setDots">
-        <xsl:with-param name="dots" select="@mm.dots"/>
-      </xsl:call-template>
-      <xsl:value-of select="concat(' = ',@mm)"/>
-    </xsl:if>
-    <xsl:value-of select="'&#10;  '"/>
     <xsl:if test="@midi.bpm and not(@mm)">
       <xsl:text>\once \set Score.tempoHideNote = ##t&#32;</xsl:text>
       <xsl:value-of select="concat('\tempo 4 = ',@midi.bpm,'&#10;  ')"/>

--- a/tests/tempo-mm-without-mm-count.mei
+++ b/tests/tempo-mm-without-mm-count.mei
@@ -1,0 +1,33 @@
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="3.0.0">
+   <meiHead>
+     <fileDesc>
+       <titleStmt>
+         <title></title>
+       </titleStmt>
+       <pubStmt></pubStmt>
+     </fileDesc>
+   </meiHead>
+   <music>
+      <body>
+         <mdiv>
+            <score>
+               <scoreDef meter.count="3" meter.unit="8">
+                  <staffGrp>
+                     <staffDef n="1" clef.line="2" clef.shape="G" lines="5"/>
+                  </staffGrp>
+               </scoreDef>
+               <section>
+                  <measure n="1">
+                     <staff n="1">
+                        <layer n="1">
+                           <rest dur="4" dots="1"/>
+                        </layer>
+                     </staff>
+                     <tempo tstamp="1" place="above" staff="1" mm="92"/>
+                  </measure>
+               </section>
+            </score>
+         </mdiv>
+      </body>
+   </music>
+</mei>


### PR DESCRIPTION
If we don't have both `@mm` and `@mm.unit` present, we get a syntax error.

This situation occurs in the following files of the sample library:

```
MEI3/Music/Complete examples/Handel_Arie.mei
MEI3/Music/Complete examples/Handel_Messias.mei
MEI3/Music/Complete examples/Aguado_Walzer_G-major.mei
MEI3/Music/Complete examples/Parker-Gillespie_ShawNuff.mei
MEI3/Music/Complete examples/Beethoven_Hymn_to_joy.mei
MEI3/Music/Complete examples/Schubert_Erlkönig.mei
MEI3/Music/Complete examples/Webern_VariationsforPiano.mei
```

Test file is included.
