### PR TITLE
Accept elements with namespace prefix

### DIFF
--- a/mei2ly.xsl
+++ b/mei2ly.xsl
@@ -265,7 +265,7 @@
             <xsl:value-of select="concat(ancestor::mei:mdiv[1]//mei:staffDef[@n=$staffNumber][1]/@lyric.weight,' ')"/>
           </xsl:if>
           <xsl:for-each select="ancestor::mei:mdiv[1]//mei:staff[@n=$staffNumber]/mei:layer[1]">
-            <xsl:for-each select="descendant::*[name()='note' or name()='rest' or name()='mRest']">
+            <xsl:for-each select="descendant::*[self::mei:note or self::mei:rest or self::mei:mRest]">
               <xsl:if test="not(@grace)">
                 <xsl:choose>
                   <xsl:when test="descendant::mei:syl">
@@ -274,7 +274,7 @@
                   <xsl:when test="@syl">
                     <xsl:value-of select="concat(' ',@syl)"/>
                   </xsl:when>
-                  <xsl:when test="name()='note' or max(ancestor::mei:mdiv[1]//mei:staff[@n=$staffNumber]/mei:layer/@n) &gt; 1">
+                  <xsl:when test="self::mei:note or max(ancestor::mei:mdiv[1]//mei:staff[@n=$staffNumber]/mei:layer/@n) &gt; 1">
                     <xsl:value-of select="'_'"/>
                   </xsl:when>
                 </xsl:choose>
@@ -623,7 +623,7 @@
       </xsl:choose>
     </xsl:variable>
     <xsl:if test="$clefColor">
-      <xsl:if test="name()='clef'">
+      <xsl:if test="self::mei:clef">
         <xsl:value-of select="'\once '"/>
       </xsl:if>
       <xsl:value-of select="'\override Staff.Clef.color = #'"/>

--- a/tests/namespace-prefixes.mei
+++ b/tests/namespace-prefixes.mei
@@ -1,0 +1,36 @@
+<mei:mei xmlns:mei="http://www.music-encoding.org/ns/mei" meiversion="3.0.0">
+   <mei:meiHead>
+     <mei:fileDesc>
+       <mei:titleStmt>
+         <mei:title></mei:title>
+       </mei:titleStmt>
+       <mei:pubStmt></mei:pubStmt>
+     </mei:fileDesc>
+   </mei:meiHead>
+   <mei:music>
+      <mei:body>
+         <mei:mdiv>
+            <mei:score>
+               <mei:scoreDef meter.count="4" meter.unit="4">
+                  <mei:staffGrp>
+                     <mei:staffDef n="1" clef.line="2" clef.shape="G" lines="5"/>
+                  </mei:staffGrp>
+               </mei:scoreDef>
+               <mei:section>
+                  <mei:measure n="1">
+                     <mei:staff n="1">
+                        <mei:layer n="1">
+                           <mei:note pname="g" oct="4" dur="1">
+                             <mei:verse n="1">
+                               <mei:syl>testlyrics</mei:syl>
+                             </mei:verse>
+                           </mei:note>
+                        </mei:layer>
+                     </mei:staff>
+                  </mei:measure>
+               </mei:section>
+            </mei:score>
+         </mei:mdiv>
+      </mei:body>
+   </mei:music>
+</mei:mei>


### PR DESCRIPTION
It's generally a good idea not to use `name()` on elements that are in a namespace because they might have a prefix. This adds a test for lyrics.
