### PR TITLE
Ignore annots and comments so they don't disrupt the lilypond input code

### DIFF
--- a/mei2ly.xsl
+++ b/mei2ly.xsl
@@ -2068,6 +2068,8 @@
   <xsl:template match="mei:sourceDesc"/>
   <xsl:template match="mei:symbol"/>
   <xsl:template match="mei:vel"/>
+  <xsl:template match="comment()"/>
+  <xsl:template match="mei:annot"/>
   <!-- helper templates -->
   <!-- tag contents-->
   <xsl:template name="tag">

--- a/tests/annots-and-comments.mei
+++ b/tests/annots-and-comments.mei
@@ -1,0 +1,36 @@
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="3.0.0">
+  <meiHead>
+    <fileDesc>
+      <titleStmt>
+        <title/>
+      </titleStmt>
+      <pubStmt/>
+    </fileDesc>
+  </meiHead>
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4">
+            <staffGrp>
+              <staffDef n="1" clef.line="2" clef.shape="G" lines="5"/>
+            </staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <rest dur="1"/>
+                  <!-- Some comment \ { @ ! -->
+                  <annot>
+                    Some annot \ {@ ! 
+                  </annot>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>


### PR DESCRIPTION
Depending on where an `<annot>` occurs, it might currently disrupt the Lilypond input code as its content might be copied by `<apply-templates>`. Comments are likely not a problem, but it doesn't hurt to ignore them explicitly.
