### PR TITLE
Beams: Use keys and new template mode addBeamMarkup

### DIFF
--- a/tests/beams.mei
+++ b/tests/beams.mei
@@ -1,0 +1,64 @@
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="3.0.0">
+   <meiHead>
+     <fileDesc>
+       <titleStmt>
+         <title></title>
+       </titleStmt>
+       <pubStmt></pubStmt>
+     </fileDesc>
+     <workDesc>
+       <work>
+         <titleStmt>
+           <title></title>
+         </titleStmt>
+       </work>
+     </workDesc>
+   </meiHead>
+   <music>
+      <body>
+         <mdiv>
+            <score>
+               <scoreDef meter.count="4" meter.unit="4">
+                  <staffGrp>
+                     <staffDef n="1" clef.line="2" clef.shape="G" lines="5"/>
+                  </staffGrp>
+               </scoreDef>
+               <section>
+                 <measure n="1">
+                   <staff n="1">
+                     <layer n="1">
+                       <beam>
+                         <note pname="g" oct="4" dur="8"/>
+                         <note pname="g" oct="4" dur="8"/>
+                         <note pname="g" oct="4" dur="8"/>
+                         <handShift/>
+                       </beam>
+                       <note pname="g" oct="4" dur="8"/>
+                       <note pname="g" oct="4" dur="8"/>
+                       <note pname="g" oct="4" dur="8" xml:id="note6"/>
+                       <note pname="g" oct="4" dur="8" xml:id="note7"/>
+                       <note pname="g" oct="4" dur="8" xml:id="note8"/>
+                       <beamSpan startid="#note6" endid="#note8"/>
+                     </layer>
+                   </staff>
+                 </measure>
+                 <measure n="2">
+                   <staff n="1">
+                     <layer n="1">
+                       <note pname="g" oct="4" dur="8"/>
+                       <note pname="g" oct="4" dur="8"/>
+                       <note pname="g" oct="4" dur="8"/>
+                       <note pname="g" oct="4" dur="8" beam="i1"/>
+                       <note pname="g" oct="4" dur="8" beam="t1"/>
+                       <note pname="g" oct="4" dur="8"/>
+                       <note pname="g" oct="4" dur="8"/>
+                       <note pname="g" oct="4" dur="8"/>
+                     </layer>
+                   </staff>
+                 </measure>
+               </section>
+            </score>
+         </mdiv>
+      </body>
+   </music>
+</mei>


### PR DESCRIPTION
I did some changes to remove code duplication and hence improve maintainability because when refining the beaming logic, the code doesn't have to be changed in multiple places.

It sort of reverses the logic, i.e. instead of starting from a `<note>`/`<chord>`/`<rest>` and looking for a corresponding `<beam>`/`<beamSpan>`, the keys start at the `<beam>`/`<beamSpan>`s and find the elements they are anchored to.  I expect this to be more efficient because:

* there are less `<beam>`/`<beamSpan>` elements than `<note>`s/`<chord>`s/`<rest>`s elements - i.e. the number of tests should be lower
* when starting from `<note>`/`<chord>`/`<rest>`, we don't know whether a beam was specified using `<beam>`s or `<beamSpan>`, so we have to check for both things. When starting from `<beam>`/`<beamSpan>` this problem does not occur.

This new solution is also more robust. In the also included beams test case, the first beam fails to render correctly as the last element in it is a `<handShift>` - which is a perfectly valid (though maybe not a very clever) place to put a `<handShift>`.

A similar approach could be taken e.g. for slurs and hairpins.