### PR TITLE
Support partial measures of arbitrary length

### DIFF
--- a/mei2ly.xsl
+++ b/mei2ly.xsl
@@ -239,7 +239,7 @@
         </xsl:if>
         <xsl:apply-templates select="ancestor::mei:measure/mei:tempo[@copyof or contains(concat(' ',@staff,' '),concat(' ',$staffNumber,' '))][@tstamp='1']" mode="pre" />
         <xsl:if test="ancestor::mei:measure/@metcon='false'">
-          <xsl:value-of select="concat('\partial ',min(ancestor::mei:measure/descendant::*/@dur),'&#32;')" />
+          <xsl:apply-templates select="descendant::mei:layer[1]" mode="setPartial"/>
         </xsl:if>
         <xsl:text>&lt;&lt;&#32;</xsl:text>
         <xsl:choose>
@@ -581,7 +581,7 @@
       </xsl:call-template>
     </xsl:if>
     <xsl:if test="@metcon='false'">
-      <xsl:value-of select="concat('\partial ',min(ancestor::mei:measure/descendant::*/@dur),'&#32;')" />
+      <xsl:apply-templates select="descendant::mei:layer[1]" mode="setPartial"/>
     </xsl:if>
     <xsl:apply-templates/>
     <xsl:if test="@right">
@@ -4073,5 +4073,39 @@
         <xsl:value-of select="0"/>
       </xsl:otherwise>
     </xsl:choose>
+  </xsl:function>
+  <xsl:template match="mei:layer" mode="setPartial">
+    <xsl:variable name="durElements" select="descendant::*[@dur][not(ancestor::mei:chord)]" as="element()*"/>
+    <!-- Seems paradox: To get the smallest @dur, we use max() (16ths are smaller than 8th) -->
+    <xsl:variable name="smallestDur" select="max($durElements/@dur/xs:integer(.))" as="xs:integer"/>
+    <xsl:variable name="largestDots" select="max(($durElements/@dots/xs:integer(.), 0))" as="xs:integer"/>
+    <xsl:variable name="durUnit" select="$smallestDur * round(local:power(2, $largestDots))" as="xs:integer"/>
+    <xsl:variable name="dursInUnit" as="xs:integer*">
+      <xsl:apply-templates select="$durElements" mode="addToDurSum">
+        <xsl:with-param name="durUnit" select="$durUnit"/>
+      </xsl:apply-templates>
+    </xsl:variable>
+    <!-- We might have a measure with non-numerical @durs, so test if we'd output something valid -->
+    <xsl:if test="$dursInUnit[1]">
+      <xsl:value-of select="concat('\set Timing.measurePosition = #(ly:make-moment -', sum($dursInUnit), '/', $durUnit, ') ')"/>
+    </xsl:if>
+  </xsl:template>
+  <xsl:template mode="addToDurSum" name="addToDurSum" match="*[@dur]">
+    <xsl:param name="durUnit"/>
+    <xsl:param name="durInUnits" select="$durUnit idiv xs:integer(@dur)"/>
+    <xsl:param name="dots" select="if (@dots) then xs:integer(@dots) else 0"/>
+    <xsl:sequence select="$durInUnits"/>
+    <xsl:if test="$dots gt 0">
+      <xsl:apply-templates select="." mode="addToDurSum">
+        <xsl:with-param name="dots" select="$dots - 1"/>
+        <xsl:with-param name="durInUnits" select="$durInUnits idiv 2"/>
+        <xsl:with-param name="durUnit" select="$durUnit"/>
+      </xsl:apply-templates>
+    </xsl:if>
+  </xsl:template>
+  <xsl:function name="local:power">
+    <xsl:param name="radix" as="xs:integer"/>
+    <xsl:param name="exponent" as="xs:integer"/>
+    <xsl:sequence select="if ($exponent le 0) then 1 else $radix * local:power($radix, $exponent - 1)"/>
   </xsl:function>
 </xsl:stylesheet>

--- a/tests/partial-measures.mei
+++ b/tests/partial-measures.mei
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.music-encoding.org/schema/3.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="http://www.music-encoding.org/schema/3.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="3.0.0" xmlns:meiler="NS:MEILER_TEST">
+  <meiHead>
+     <fileDesc>
+       <titleStmt>
+         <title></title>
+       </titleStmt>
+       <pubStmt></pubStmt>
+     </fileDesc>
+     <extMeta>
+       <meiler:test system="bash" input="ly">
+         # For the first measure, we expect the output `ly:make-moment -12/32`
+         # because we apply the largest @dots value to the smallest duration
+         # for the denominator (which is 1 dot applied to 16th notes, resulting
+         # in 32nd notes).
+         grep 'ly:make-moment -12/32' "$ly" \
+         &amp;&amp; grep 'ly:make-moment -5/8' "$ly"
+       </meiler:test>
+     </extMeta>
+   </meiHead>
+   <music>
+      <body>
+         <mdiv>
+            <score>
+               <scoreDef meter.count="4" meter.unit="4">
+                  <staffGrp>
+                     <staffDef n="1" clef.line="2" clef.shape="G" lines="5"/>
+                  </staffGrp>
+               </scoreDef>
+               <section>
+                 <measure n="1" metcon="false">
+                   <staff n="1">
+                     <layer n="1">
+                       <note pname="e" oct="4" dur="8"/>
+                       <beam>
+                         <note pname="f" oct="4" dur="8" dots="1"/>
+                         <note pname="g" oct="4" dur="16"/>
+                       </beam>
+                     </layer>
+                   </staff>
+                 </measure>
+                 <measure n="2">
+                   <staff n="1">
+                     <layer n="1">
+                       <note dur="2" pname="a" oct="4"/>
+                       <rest dur="8"/>
+                       <note pname="g" oct="4" dur="8"/>
+                       <beam>
+                         <note pname="f" oct="4" dur="8" dots="1"/>
+                         <note pname="e" oct="4" dur="16"/>
+                       </beam>
+                     </layer>
+                   </staff>
+                 </measure>
+                 <measure n="3" metcon="false">
+                   <staff n="1">
+                     <layer n="1">
+                       <note dur="2" pname="d" oct="4"/>
+                       <rest dur="8"/>
+                     </layer>
+                   </staff>
+                 </measure>
+               </section>
+            </score>
+         </mdiv>
+      </body>
+   </music>
+</mei>


### PR DESCRIPTION
This calculates the duration of a partial measure. It still relies on `@metcon` to be set.