### PR TITLE
Support layers that are not in ascending order according to @n

### DIFF
--- a/mei2ly.xsl
+++ b/mei2ly.xsl
@@ -659,7 +659,7 @@
   <xsl:template match="mei:layer">
     <xsl:param name="needsDivider" select="false()" as="xs:boolean"/>
     <xsl:param name="oneVoice" select="false()"/>
-    <xsl:if test="preceding-sibling::mei:layer or $needsDivider">
+    <xsl:if test="(not($forceContinueVoices) and preceding-sibling::mei:layer) or $needsDivider">
       <xml:text>\\ </xml:text>
     </xsl:if>
     <xsl:if test="$oneVoice">

--- a/tests/spanners-across-measures.mei
+++ b/tests/spanners-across-measures.mei
@@ -64,12 +64,13 @@
             </measure>
             <measure xml:id="measure4" n="4">
               <staff xml:id="staff4" n="1">
+                <!-- Test "misordered layers -->
+                <layer xml:id="layer6" n="2">
+                  <note xml:id="note6" pname="f" oct="4" dur="1"/>
+                </layer>
                 <layer xml:id="layer5" n="1">
                   <note xml:id="note5" pname="a" oct="4" dur="8"/>
                   <rest xml:id="rest4" dur="2" dots="2"/>
-                </layer>
-                <layer xml:id="layer6" n="2">
-                  <note xml:id="note6" pname="f" oct="4" dur="1"/>
                 </layer>
               </staff>
             </measure>


### PR DESCRIPTION
For some reason, sibmei can output layers in the "wrong" order, e.g. layer 2 before layer 1. This would result in an additional `\\` before the first voice because voice 1 sees a preceding voice.