### PR TITLE
Fix parameter value in test file committed for b5d433c

### DIFF
--- a/tests/spanners-across-measures.mei
+++ b/tests/spanners-across-measures.mei
@@ -14,7 +14,7 @@
     </fileDesc>
     <extMeta>
       <meiler:test system="bash" input="lystderr">
-        <meiler:param name="forceContinueVoices" value="yes"/>
+        <meiler:param name="forceContinueVoices" value="true"/>
         if grep 'unterminated' "$lystderr"
         then
             echo "Unterminated spanners" 


### PR DESCRIPTION
There's no automated test system (yet), but even when testing manually, it must be clear that `true` must be supplied instead of `yes`.